### PR TITLE
chore(tsconfig): index.ts追加, libに生成して生成物を無視

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+lib/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wwa_macro_parser",
   "version": "1.0.0",
   "description": "WWA Macro Parser",
-  "main": "index.js",
+  "main": "./lib",
   "scripts": {
     "test": "jest",
     "tsc": "tsc"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { Parser } from "./parser";
+export { MacroParser } from "./macro_parser";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    "outDir": "./lib",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "removeComments": true,                /* Do not emit comments to output. */


### PR DESCRIPTION
# 概要
- index.ts を追加 利用側から簡単にimport できるようにする
- lib に生成して、gitの追跡対象から外す

## 動作確認
- [x] npm run tsc
