### PR TITLE
fix: 数値のバリデーションをしないようにする, ネストされた引数の再帰に対応

### DIFF
--- a/src/macro_parser.test.ts
+++ b/src/macro_parser.test.ts
@@ -25,8 +25,7 @@ describe('parse imgplayer', () => {
         expect(new MacroParser(message).parse()).toEqual(new Macro('imgplayer', ['1', '2']));
     });
     it('failure', () => {
-        const message = '$imgplayer=1';
-        expect(new MacroParser(message).parse()).toEqual(message);
+        expect(new MacroParser('$imgplayer=1').parse()).toEqual("");
     });
 });
 
@@ -37,7 +36,7 @@ describe('parse imgyesno', () => {
     });
     it('failure', () => {
         const message = '$imgyesno=1';
-        expect(new MacroParser(message).parse()).toEqual(message);
+        expect(new MacroParser(message).parse()).toEqual("");
     });
 });
 
@@ -48,7 +47,7 @@ describe('parse hpmax', () => {
     });
     it('failure', () => {
         const message = '$hpmax=hoge';
-        expect(new MacroParser(message).parse()).toEqual(message);
+        expect(new MacroParser(message).parse()).toEqual("");
     });
 });
 
@@ -58,10 +57,9 @@ describe('parse save', () => {
         expect(new MacroParser(message).parse()).toEqual(new Macro('save', ['0']));
         message = '$save=1';
         expect(new MacroParser(message).parse()).toEqual(new Macro('save', ['1']));
-    });
-    it('failure', () => {
-        const message = '$save=2';
-        expect(new MacroParser(message).parse()).toEqual(message);
+        // 想定されていない値でもパースは成功する (値のバリデーションはアプリケーション側の責務)
+        message = '$save=2';
+        expect(new MacroParser(message).parse()).toEqual(new Macro('save', ['2']));
     });
 });
 
@@ -71,10 +69,8 @@ describe('parse item', () => {
         expect(new MacroParser(message).parse()).toEqual(new Macro('item', ['0', '5']));
         message = '$item=11,90';
         expect(new MacroParser(message).parse()).toEqual(new Macro('item', ['11', '90']));
-    });
-    it('failure', () => {
-        const message = '$item=23,5';
-        expect(new MacroParser(message).parse()).toEqual(message);
+        message = '$item=23,5';
+        expect(new MacroParser(message).parse()).toEqual(new Macro('item', ['23', '5']));
     });
 });
 
@@ -85,10 +81,11 @@ describe('parse default', () => {
         expect(new MacroParser(`$${name}=0`).parse()).toEqual(new Macro(name, ['0']));
         message = '$default=1';
         expect(new MacroParser(`$${name}=1`).parse()).toEqual(new Macro(name, ['1']));
+        message = '$default=2';
+        expect(new MacroParser(`$${name}=2`).parse()).toEqual(new Macro(name, ['2']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=2,`).parse()).toEqual(`$${name}=2,`);
-        expect(new MacroParser(`$${name}=2`).parse()).toEqual(`$${name}=2`);
+        expect(new MacroParser(`$${name}=2,`).parse()).toEqual("");
     });
 });
 
@@ -97,10 +94,10 @@ describe('parse oldmap', () => {
     it('success', () => {
         expect(new MacroParser(`$${name}=0`).parse()).toEqual(new Macro(name, ['0']));
         expect(new MacroParser(`$${name}=1`).parse()).toEqual(new Macro(name, ['1']));
+        expect(new MacroParser(`$${name}=2`).parse()).toEqual(new Macro(name, ['2']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=2,3`).parse()).toEqual(`$${name}=2,3`);
-        expect(new MacroParser(`$${name}=2`).parse()).toEqual(`$${name}=2`);
+        expect(new MacroParser(`$${name}=2,3`).parse()).toEqual("");
     });
 });
 
@@ -110,10 +107,10 @@ describe('parse parts', () => {
         expect(new MacroParser(`$${name}=4,10`).parse()).toEqual(new Macro(name, ['4', '10']));
         expect(new MacroParser(`$${name}=9,72,0`).parse()).toEqual(new Macro(name, ['9', '72', '0']));
         expect(new MacroParser(`$${name}=6,15,1`).parse()).toEqual(new Macro(name, ['6', '15', '1']));
+        expect(new MacroParser(`$${name}=9,72,2`).parse()).toEqual(new Macro(name, ['9', '72', '2']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=4,10,`).parse()).toEqual(`$${name}=4,10,`);
-        expect(new MacroParser(`$${name}=9,72,2`).parse()).toEqual(`$${name}=9,72,2`);
+        expect(new MacroParser(`$${name}=4,10,`).parse()).toEqual("");
     });
 });
 
@@ -121,10 +118,10 @@ describe('parse face', () => {
     const name = 'face';
     it('success', () => {
         expect(new MacroParser(`$${name}=100,110,5,10,1,1`).parse()).toEqual(new Macro(name, ['100', '110', '5', '10', '1', '1']));
+        expect(new MacroParser(`$${name}=100,110,5,10,1,1,2`).parse()).toEqual("");
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=100,110,5,10,1`).parse()).toEqual(`$${name}=100,110,5,10,1`);
-        expect(new MacroParser(`$${name}=100,110,5,10,1,1,2`).parse()).toEqual(`$${name}=100,110,5,10,1,1,2`);
+        expect(new MacroParser(`$${name}=100,110,5,10,1`).parse()).toEqual("");
     });
 });
 
@@ -133,10 +130,10 @@ describe('parse delplayer', () => {
     it('success', () => {
         expect(new MacroParser(`$${name}=0`).parse()).toEqual(new Macro(name, ['0']));
         expect(new MacroParser(`$${name}=1`).parse()).toEqual(new Macro(name, ['1']));
+        expect(new MacroParser(`$${name}=2`).parse()).toEqual(new Macro(name, ['2']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=2,3`).parse()).toEqual(`$${name}=2,3`);
-        expect(new MacroParser(`$${name}=2`).parse()).toEqual(`$${name}=2`);
+        expect(new MacroParser(`$${name}=2,3`).parse()).toEqual("");
     });
 });
 
@@ -147,9 +144,8 @@ describe('parse imgclick', () => {
         expect(new MacroParser(`$${name}=7,13`).parse()).toEqual(new Macro(name, ['7', '13']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=1`).parse()).toEqual(`$${name}=1`);
-        expect(new MacroParser(`$${name}=1,`).parse()).toEqual(`$${name}=1,`);
-        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual(`$${name}=1,2,`);
+        expect(new MacroParser(`$${name}=1,`).parse()).toEqual("");
+        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual("");
     });
 });
 
@@ -162,12 +158,6 @@ describe('parse color', () => {
         expect(new MacroParser(`$${name}=4,53,53,53`).parse()).toEqual(new Macro(name, ['4', '53', '53', '53']));
         expect(new MacroParser(`$${name}=0,209,217,231`).parse()).toEqual(new Macro(name, ['0', '209', '217', '231']));
     });
-    it('failure', () => {
-        expect(new MacroParser(`$${name}=3,255,255,255`).parse()).toEqual(`$${name}=3,255,255,255`);
-        expect(new MacroParser(`$${name}=5,255,255,255`).parse()).toEqual(`$${name}=5,255,255,255`);
-        expect(new MacroParser(`$${name}=0,256,256,256`).parse()).toEqual(`$${name}=0,256,256,256`);
-        expect(new MacroParser(`$${name}=0,-1,-1,-1`).parse()).toEqual(`$${name}=0,-1,-1,-1`);
-    });
 });
 
 describe('parse gameover', () => {
@@ -176,7 +166,7 @@ describe('parse gameover', () => {
         expect(new MacroParser(`$${name}=1,2`).parse()).toEqual(new Macro(name, ['1', '2']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=1`).parse()).toEqual(`$${name}=1`);
+        expect(new MacroParser(`$${name}=1`).parse()).toEqual("");
     });
 });
 
@@ -186,11 +176,11 @@ describe('parse dirmap', () => {
         expect(new MacroParser(`$${name}=1,2`).parse()).toEqual(new Macro(name, ['1', '2']));
         expect(new MacroParser(`$${name}=1,2,0`).parse()).toEqual(new Macro(name, ['1', '2', '0']));
         expect(new MacroParser(`$${name}=1,2,1`).parse()).toEqual(new Macro(name, ['1', '2', '1']));
+        expect(new MacroParser(`$${name}=1,2,2`).parse()).toEqual(new Macro(name, ['1', '2', '2']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=1,2,2`).parse()).toEqual(`$${name}=1,2,2`);
-        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual(`$${name}=1,2,`);
-        expect(new MacroParser(`$${name}=1`).parse()).toEqual(`$${name}=1`);
+        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual("");
+        expect(new MacroParser(`$${name}=1`).parse()).toEqual("");
     });
 });
 
@@ -200,11 +190,11 @@ describe('parse map', () => {
         expect(new MacroParser(`$${name}=1,2,3`).parse()).toEqual(new Macro(name, ['1', '2', '3']));
         expect(new MacroParser(`$${name}=1,2,3,0`).parse()).toEqual(new Macro(name, ['1', '2', '3', '0']));
         expect(new MacroParser(`$${name}=1,2,3,1`).parse()).toEqual(new Macro(name, ['1', '2', '3', '1']));
+        expect(new MacroParser(`$${name}=1,2,3,2`).parse()).toEqual(new Macro(name, ['1', '2', '3', '2']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=1,2,3,2`).parse()).toEqual(`$${name}=1,2,3,2`);
-        expect(new MacroParser(`$${name}=1,2,3,`).parse()).toEqual(`$${name}=1,2,3,`);
-        expect(new MacroParser(`$${name}=1`).parse()).toEqual(`$${name}=1`);
+        expect(new MacroParser(`$${name}=1,2,3,`).parse()).toEqual("");
+        expect(new MacroParser(`$${name}=1`).parse()).toEqual("");
     });
 });
 
@@ -214,8 +204,8 @@ describe('parse imgframe', () => {
         expect(new MacroParser(`$${name}=1,2,3`).parse()).toEqual(new Macro(name, ['1', '2', '3']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=1,2,3,`).parse()).toEqual(`$${name}=1,2,3,`);
-        expect(new MacroParser(`$${name}=1,2`).parse()).toEqual(`$${name}=1,2`);
+        expect(new MacroParser(`$${name}=1,2,3,`).parse()).toEqual("");
+        expect(new MacroParser(`$${name}=1,2`).parse()).toEqual("");
     });
 });
 
@@ -226,8 +216,7 @@ describe('parse imgbom', () => {
         expect(new MacroParser(`$${name}=10,3`).parse()).toEqual(new Macro(name, ['10', '3']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=11,3`).parse()).toEqual(`$${name}=11,3`);
-        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual(`$${name}=1,2,`);
+        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual("");
     });
 });
 
@@ -236,11 +225,11 @@ describe('parse effect', () => {
     it('success', () => {
         expect(new MacroParser(`$${name}=100,3,4`).parse()).toEqual(new Macro(name, ['100', '3', '4']));
         expect(new MacroParser(`$${name}=5,10,10`).parse()).toEqual(new Macro(name, ['5', '10', '10']));
+        expect(new MacroParser(`$${name}=100,11,4`).parse()).toEqual(new Macro(name, ['100', '11', '4']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=100,11,4`).parse()).toEqual(`$${name}=100,11,4`);
-        expect(new MacroParser(`$${name}=11,3`).parse()).toEqual(`$${name}=11,3`);
-        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual(`$${name}=1,2,`);
+        expect(new MacroParser(`$${name}=11,3`).parse()).toEqual("");
+        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual("");
     });
 });
 
@@ -252,9 +241,8 @@ describe('parse status', () => {
         expect(new MacroParser(`$${name}=4,10000`).parse()).toEqual(new Macro(name, ['4', '10000']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=100,11,4`).parse()).toEqual(`$${name}=100,11,4`);
-        expect(new MacroParser(`$${name}=11,3`).parse()).toEqual(`$${name}=11,3`);
-        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual(`$${name}=1,2,`);
+        expect(new MacroParser(`$${name}=100,11,4`).parse()).toEqual("");
+        expect(new MacroParser(`$${name}=1,2,`).parse()).toEqual("");
     });
 });
 
@@ -265,8 +253,8 @@ describe('parse sound', () => {
         expect(new MacroParser(`$${name}=256`).parse()).toEqual(new Macro(name, ['256']));
     });
     it('failure', () => {
-        expect(new MacroParser(`$${name}=1,`).parse()).toEqual(`$${name}=1,`);
-        expect(new MacroParser(`$${name}=`).parse()).toEqual(`$${name}=`);
-        expect(new MacroParser(`$${name}=a`).parse()).toEqual(`$${name}=a`);
+        expect(new MacroParser(`$${name}=1,`).parse()).toEqual("");
+        expect(new MacroParser(`$${name}=`).parse()).toEqual("");
+        expect(new MacroParser(`$${name}=a`).parse()).toEqual("");
     });
 });


### PR DESCRIPTION
- ユーザ変数を展開する構文を導入するため、値のバリデーションはマクロパーサでは行わず、アプリケーション側で実施する
- 上記実施に伴い、 `$imgframe` (1引数の 0 もしくは 2引数) のパーサを修正
- パーサの修正に伴い、`Parser.seq` などが入れ子になっている場合に配列引数が正しくフラット化されない不具合を修正
- `Parser.option` を利用することにより `null` がトークンとして入りうるようになったので、パース後のマクロ引数からは除去